### PR TITLE
Update Remote-Falcon library to new commit reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'io.quarkus:quarkus-undertow'
     implementation 'org.apache.commons:commons-lang3:3.x'
     implementation 'commons-collections:commons-collections:3.2.2'
-    implementation ('com.github.Remote-Falcon:remote-falcon-library:9cb8f5ade2') {
+    implementation ('com.github.Remote-Falcon:remote-falcon-library:685018c867') {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-data-mongodb"
     }
     implementation 'io.quarkus:quarkus-smallrye-health'


### PR DESCRIPTION
Updated the Remote-Falcon library from commit `9cb8f5ade2` to `685018c867`. This ensures the project uses the latest changes and fixes from the library while maintaining the same exclusion for spring-boot-starter-data-mongodb.