### PR TITLE
Adds REST endpoints for sequence voting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-mongodb-panache'
     implementation 'io.quarkus:quarkus-resteasy'
+    implementation 'io.quarkus:quarkus-resteasy-jackson'
     implementation 'io.quarkus:quarkus-smallrye-graphql'
     implementation 'io.quarkus:quarkus-arc'
     implementation 'io.quarkus:quarkus-opentelemetry'

--- a/src/main/java/com/remotefalcon/controller/RestController.java
+++ b/src/main/java/com/remotefalcon/controller/RestController.java
@@ -1,0 +1,57 @@
+package com.remotefalcon.controller;
+
+import com.remotefalcon.exception.CustomGraphQLExceptionResolver;
+import com.remotefalcon.request.RequestVoteRequest;
+import com.remotefalcon.response.RequestVoteResponse;
+import com.remotefalcon.service.GraphQLMutationService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+
+@ApplicationScoped
+@Path("/")
+public class RestController {
+    @Inject
+    GraphQLMutationService graphQLMutationService;
+
+    @POST
+    @Path("/addSequenceToQueue")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public RequestVoteResponse addSequenceToQueue(RequestVoteRequest request) {
+        try {
+            this.graphQLMutationService.addSequenceToQueue(
+                    request.getShowSubdomain(),
+                    request.getSequence(),
+                    request.getViewerLatitude().doubleValue(),
+                    request.getViewerLongitude().doubleValue()
+            );
+            return RequestVoteResponse.builder().build();
+        }catch (CustomGraphQLExceptionResolver e) {
+            return RequestVoteResponse.builder()
+                    .message(e.getExtensions().get("message").toString())
+                    .build();
+        }
+    }
+
+    @POST
+    @Path("/voteForSequence")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public RequestVoteResponse voteForSequence(RequestVoteRequest request) {
+        try {
+            this.graphQLMutationService.voteForSequence(
+                    request.getShowSubdomain(),
+                    request.getSequence(),
+                    request.getViewerLatitude().doubleValue(),
+                    request.getViewerLongitude().doubleValue()
+            );
+            return RequestVoteResponse.builder().build();
+        }catch (CustomGraphQLExceptionResolver e) {
+            return RequestVoteResponse.builder()
+                    .message(e.getExtensions().get("message").toString())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/remotefalcon/exception/CustomGraphQLExceptionResolver.java
+++ b/src/main/java/com/remotefalcon/exception/CustomGraphQLExceptionResolver.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 @Provider
-public class CustomerGraphQLExceptionResolver extends RuntimeException implements GraphQLError {
-    public CustomerGraphQLExceptionResolver(String errorMessage) {
+public class CustomGraphQLExceptionResolver extends RuntimeException implements GraphQLError {
+    public CustomGraphQLExceptionResolver(String errorMessage) {
         super(errorMessage);
     }
 

--- a/src/main/java/com/remotefalcon/request/RequestVoteRequest.java
+++ b/src/main/java/com/remotefalcon/request/RequestVoteRequest.java
@@ -1,0 +1,17 @@
+package com.remotefalcon.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestVoteRequest {
+    private Float viewerLatitude;
+    private Float viewerLongitude;
+    private String sequence;
+    private String showSubdomain;
+}

--- a/src/main/java/com/remotefalcon/response/RequestVoteResponse.java
+++ b/src/main/java/com/remotefalcon/response/RequestVoteResponse.java
@@ -1,0 +1,14 @@
+package com.remotefalcon.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestVoteResponse {
+    private String message;
+}

--- a/src/main/java/com/remotefalcon/service/GraphQLQueryService.java
+++ b/src/main/java/com/remotefalcon/service/GraphQLQueryService.java
@@ -1,6 +1,6 @@
 package com.remotefalcon.service;
 
-import com.remotefalcon.exception.CustomerGraphQLExceptionResolver;
+import com.remotefalcon.exception.CustomGraphQLExceptionResolver;
 import com.remotefalcon.library.enums.StatusResponse;
 import com.remotefalcon.library.models.Request;
 import com.remotefalcon.library.models.Sequence;
@@ -122,6 +122,6 @@ public class GraphQLQueryService {
             }
             return "";
         }
-        throw new CustomerGraphQLExceptionResolver(StatusResponse.UNEXPECTED_ERROR.name());
+        throw new CustomGraphQLExceptionResolver(StatusResponse.UNEXPECTED_ERROR.name());
     }
 }


### PR DESCRIPTION
Adds REST endpoints to handle sequence requests and votes, integrating with the GraphQL mutation service.
Introduces request and response objects for the new endpoints, and includes exception handling.
Also, improves the check if a user has already voted or requested a sequence by not checking the IP address if it is empty.

Updates exception handling to use custom exceptions to return error messages to the client.
